### PR TITLE
Update der dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bookworm
+FROM python:3.14-slim-bookworm
 
 RUN apt update && apt upgrade --yes && apt install --yes python3-pip libpango-1.0-0 libpangoft2-1.0-0 libharfbuzz-subset0 libjpeg-dev libopenjp2-7-dev libffi-dev locales locales-all && apt clean
 ADD requirements.txt /tmp/requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fastapi==0.111
-weasyprint==62.3
-qrcode==7.4.2
-markdown==3.6
+fastapi[standard]==0.141.1
+weasyprint==69.0
+qrcode==8.2
+markdown==3.10.3


### PR DESCRIPTION
Versionsupdate der PIP-Pakete sowie des zugrundeliegenden Images.

Löst dabei das Problem der aktuellen Version, dass `docker image build` scheitert.